### PR TITLE
Fix typo in SC_CL_EFFECTS causing HUD to redraw every tick

### DIFF
--- a/source/a_client.acs
+++ b/source/a_client.acs
@@ -169,7 +169,7 @@ script SC_CL_EFFECTS (void) NET CLIENTSIDE {
 			GetCVar ("zeta_cl_confonthud") != last_confonthud)
 		{
 			last_nohud = GetCVar ("zeta_cl_nohud");
-			last_nohud = GetCVar ("zeta_cl_confonthud");
+			last_confonthud = GetCVar ("zeta_cl_confonthud");
 			UpdateHUD ();
 		}
 		


### PR DESCRIPTION
In the CVar change detection loop, last_confonthud was never updated because line 172 assigned to last_nohud instead. This caused the confonthud comparison to always detect a change, triggering UpdateHUD every tick once the condition first fired. 

I believe this is partially the reason why some players see the 'gray' and 'dark gray' flickering for dead or inactive structures on the HUD.