### PR TITLE
[Cata] Fix regen building showing 6553600% on HUD when spawned

### DIFF
--- a/actors/objects/regens.txt
+++ b/actors/objects/regens.txt
@@ -25,7 +25,7 @@ actor Utility_GlobalMedicCacheRed {
 	DamageFactor "Ice", 0.1
 	radius 8
 	height 64
-	speed 100 // used for base hud!
+	speed 0 // [Cata] speed is used for base hud health %; set via ACS, must be 0 here to avoid fixed-point overflow on HUD
 	health 8750
 	renderstyle Translucent
 	alpha 0.0

--- a/source/a_research.acs
+++ b/source/a_research.acs
@@ -233,6 +233,7 @@ script SC_SpawnCache (int what, int team)
 				(team == TEAM_BLUE)	? "Utility_GlobalMedicCacheBlue"
 									: "Utility_GlobalMedicCacheRed",
 				baseTID + 12, 0, 0);
+			SetActorSpeed(MainTIDs[team][BUILDING_HEALTHREGEN], 100);
 			Delay(1);
 			SYNC_UpdateBuildingHealth (BUILDING_HEALTHREGEN, team);
 			ACS_ExecuteAlways(344, 0, 6);
@@ -249,6 +250,7 @@ script SC_SpawnCache (int what, int team)
 				(team == TEAM_RED)	? "Utility_GlobalAmmoCacheRed"
 									: "Utility_GlobalAmmoCacheBlue",
 				baseTID + 13, 0, 0);
+			SetActorSpeed(MainTIDs[team][BUILDING_AMMOREGEN], 100);
 			Delay(1);
 			SYNC_UpdateBuildingHealth (BUILDING_AMMOREGEN, team);
 			ACS_ExecuteAlways(344, 0, 8);

--- a/source/a_sync.acs
+++ b/source/a_sync.acs
@@ -29,7 +29,7 @@ function void SYNC_UpdateBuildingHealth (int what, int team) {
 	int rtc = RepairCharges[1];
 	ACS_ExecuteAlways (SC_CL_SYNCCHARGES, 0, btc, rtc);
 
-	if (exists)
+	if (exists && GetActorSpawnHealth (tid) > 0)
 		perc = GetActorHealth (tid) * 99 / GetActorSpawnHealth (tid) + 1;
 	
 	if (perc < 0)


### PR DESCRIPTION
<img width="386" height="80" alt="mV4pnzm" src="https://github.com/user-attachments/assets/ffc9d965-d36a-4e5f-8f85-302a10ebaa85" />

This is a PR to fix the ^ above issue where regens spawning will sometimes show an overflowed value. 

- All Out War uses an old speed trick on DECORATE to transmit building health percentages to clients via ACS.
- Unlike other buildings, regen buildings specifically defaulted to speed 100, the HUD would briefly display 6553600% before the ACS sync overwrote it with the correct value.                                                               

Fix: Set DECORATE speed to 0 like everything else and immediately assign the correct value via ACS on spawn, so the HUD never reads the stale fixed-point default. Also added a guard against division by zero in the sync function as a safety net.   