### PR TITLE
[Cata] Show rank discount in all purchase menus and fix class graying

### DIFF
--- a/source/a_classes.acs
+++ b/source/a_classes.acs
@@ -610,8 +610,8 @@ function int CheckClassAvailability (int id) {
 	if (CheckInventory ("HasClass"))
 		return false;
 	
-	// Check cost
-	if (CheckInventory ("Credit") < Classes_int[id][CK_COST])
+	// [Cata] Check cost with discount
+	if (CheckInventory ("Credit") < Classes_int[id][CK_COST] - CalcDiscount(Classes_int[id][CK_COST]))
 		return false;
 	
 	// Check building dependencies

--- a/source/a_credits.acs
+++ b/source/a_credits.acs
@@ -237,3 +237,15 @@ function int CalcDiscount (int amount) {
 	
 	return d;
 }
+
+// [Cata] Shared price block for all menus.
+// Returns "Price: $270\nCorporal Discount: -$30" or just "Price: $300"
+function str FormatPriceBlock (int cost) {
+	if (cost <= 0)
+		return "Price: \cdfree!";
+	int discount = CalcDiscount(cost);
+	int final = cost - discount;
+	if (discount > 0)
+		return strparam(s:"Price: \cQ$\cD", d:final, s:" \cu[\cJ", s:RankTitles[GetRank()], s:" \ca-", d:(discount * 100 / cost), s:"% off\cu]");
+	return strparam(s:"Price: \cQ$\cD", d:cost);
+}

--- a/source/a_menu_factory.acs
+++ b/source/a_menu_factory.acs
@@ -28,28 +28,16 @@ script 706 (void) CLIENTSIDE {
 script 707 (int m0, int m1, int y) CLIENTSIDE {
 	int hid = MENU_HID + 21;
 	
+	// [Cata] Price first, then health
+	int Cost = Mechs_int[MenuMechs[m0][m1]][MK_COST];
+	HudMessage (s:FormatPriceBlock(Cost);
+		HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
+	y -= MENU_SPACING; hid++;
+
 	// Health
 	HudMessage (s:"Health: \cd", d:Mechs_int[MenuMechs[m0][m1]][MK_HEALTH], s:" \cqHP";
 		HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
 		y -= MENU_SPACING; hid++;
-	
-	// Price - Check for discount to apply on menu itself its easyer to read that way.
-	int Cost  = Mechs_int[MenuMechs[m0][m1]][MK_COST];
-	int Discount  = CalcDiscount(Cost);
-	int Final = Cost - Discount;
-	// HudMessage (s:"Cost: \cq$\cd", d:Mechs_int[MenuMechs[m0][m1]][MK_COST];
-	if (Cost != Final) // Has discount, show it.
-	{
-		HudMessage (s:"Cost: \cq$\cn", d:Final, s:"  \cc(\cq$\cc", d:Discount, s:" - \cq$\cd", d:Cost, s:"\cc)";
-		HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
-		y -= MENU_SPACING; hid++;
-	}
-	else
-	{
-	HudMessage (s:"Cost: \cq$\cd", d:Final;
-		HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
-		y -= MENU_SPACING; hid++;
-	}
 	
 	// Description - shifted a bit to the left to compensate for tabs
 	HudMessage (s:Mechs_str[MenuMechs[m0][m1]][MK_DESCRIPTION];

--- a/source/a_menu_purchase.acs
+++ b/source/a_menu_purchase.acs
@@ -82,19 +82,22 @@ script 703 (int m0, int m1, int y) CLIENTSIDE {
 			if (ArmorWeaknesses[i] == dtype)
 				strength = strparam (s:strength, s:" ", s:ArModColor (i), s:ArModName (i));
 		
-		// TODO: Break this down to individual hudmessages for flexibility
-		str classinfo;
-		classinfo = strparam (s:"Speed: \cD", d:(Classes_int[id][CK_SPEED] * 100) >> 16,
-			s:"\cQ%\nPrice: \cQ$\cD", d:Classes_int[id][CK_COST],
-			s:"\nArmor: \cDGrade ", s:ArmorColor (armor), d:armor, s:" ", s:ArModColor (armod), s:ArModName (armod));
-			
+		// [Cata] Restructured: price first, then discount, then stats
+		int classCost = Classes_int[id][CK_COST];
+		str classinfo = FormatPriceBlock(classCost);
+
+		// Stats block
+		classinfo = strparam (s:classinfo,
+			s:"\nSpeed: \cD", d:(Classes_int[id][CK_SPEED] * 100) >> 16,
+			s:"\cQ%\nArmor: \cDGrade ", s:ArmorColor (armor), d:armor, s:" ", s:ArModColor (armod), s:ArModName (armod));
+
 		// Unless we're a support class, write down strengths and weaknesses
 		if (Classes_int[id][CK_FLAGS] & CF_IsTimeCop) {
 			classinfo = strparam (s:classinfo,
 				s:"\nStrength: ", s:strength,
 				s:"\nWeakness: ", s:weakness);
 		}
-		
+
 		// Write down the rest of the info
 		classinfo = strparam (s:classinfo,
 			s:"\nGrenades: \cD", d:Classes_int[id][CK_FRAGS],
@@ -102,14 +105,17 @@ script 703 (int m0, int m1, int y) CLIENTSIDE {
 			s:"\n----\n\cD",
 			s:item0, s:"\n\cD", s:item1, s:"\n\cD", s:item2, s:"\n\cD",
 			s:item3, s:"\n\cD", s:item4, s:"\n\cD", s:item5, s:"\n\cD");
-		
+
 		// Draw it now.
 		HudMessage (s:classinfo; HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X4, y, 0.0);
+		HudMessage (s:""; HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
 		break;
 	case 4:
-		ACS_ExecuteWithResult (330, Addons_int[m1][ADK_COST] - CalcDiscount(Addons_int[m1][ADK_COST]));
-		HudMessage (s:"Price: \cQ$\cD", d:Addons_int[m1][ADK_COST];
+		// [Cata] Show discounted price with rank discount line
+		int addonCost = Addons_int[m1][ADK_COST];
+		HudMessage (s:FormatPriceBlock(addonCost);
 			HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X4, y, 0.0);
+		HudMessage (s:""; HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
 		break;
 	case 5:
 		// Resign description
@@ -120,6 +126,7 @@ script 703 (int m0, int m1, int y) CLIENTSIDE {
 				s:"sans add-on weapons and\n",
 				s:"items.";
 			HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X3, y, 0.0);
+		HudMessage (s:""; HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
 		break;
 	case 6:
 		// surrender descript
@@ -131,6 +138,7 @@ script 703 (int m0, int m1, int y) CLIENTSIDE {
 				s:"again to cancel your\n",
 				s:"vote.";
 			HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X3, y, 0.0);
+		HudMessage (s:""; HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
 		break;
 	}
 	

--- a/source/a_menu_research.acs
+++ b/source/a_menu_research.acs
@@ -25,14 +25,15 @@ script 704 (void) CLIENTSIDE {
 // =============================================================================
 // MENU DRAW
 script 705 (int m0, int m1, int y) CLIENTSIDE {
-	HudMessage (s:Researches_str[MenuResearches[m0][m1]][RCK_DESCRIPTION];
+	// [Cata] Price first, then description
+	int resCost = Researches_int[MenuResearches[m0][m1]][RCK_COST];
+	HudMessage (s:FormatPriceBlock(resCost);
 		HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X4, y, 0.0);
-	y -= 0.1;
-		
-	// Price
-	HudMessage (s:"Cost: \cq$\cd", d:Researches_int[MenuResearches[m0][m1]][RCK_COST];
-		HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
 	y -= MENU_SPACING;
+
+	HudMessage (s:Researches_str[MenuResearches[m0][m1]][RCK_DESCRIPTION];
+		HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
+	y -= 0.1;
 	
 	SetResultValue (y);
 }

--- a/source/a_menu_util.acs
+++ b/source/a_menu_util.acs
@@ -26,20 +26,17 @@ script 700 (void) CLIENTSIDE {
 script 701 (int m0, int m1, int y) CLIENTSIDE {
 	int x = PF_FindDefByMenuCoords (m0, m1);
 	
+	// [Cata] Price first, then description, then build time
+	int utilCost = g_ParticleFuserData_int[x][UK_COST];
+	HudMessage (s:FormatPriceBlock(utilCost);
+		HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X4, y, 0.0);
+	y -= MENU_SPACING;
+
 	// Description
 	HudMessage (s:g_ParticleFuserData_str[x][UK_DESCRIPTION];
-		HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X4, y, 0.0);
+		HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
 	y -= 0.1;
-	
-	// Price
-	if (g_ParticleFuserData_int[x][UK_COST] > 0)
-		HudMessage (s:"Cost: \cq$\cd", d:g_ParticleFuserData_int[x][UK_COST];
-			HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
-	else
-		HudMessage (s:"Cost: \cdfree!";
-			HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
-	y -= MENU_SPACING;
-	
+
 	// Build time
 	if (g_ParticleFuserData_int[x][UK_BUILDTIME] > 0) {
 		HudMessage (s:"Build time: \cd", f:g_ParticleFuserData_int[x][UK_BUILDTIME], s:" \cqseconds";


### PR DESCRIPTION
<img width="709" height="197" alt="v3HcJJ3" src="https://github.com/user-attachments/assets/2c5a4de7-b090-49c7-a16f-539c15f6bf01" />
<img width="496" height="222" alt="Zdsqbvt" src="https://github.com/user-attachments/assets/b3c2dd43-844b-44ab-90be-409eaed63c4c" />
<img width="707" height="325" alt="Bo5dNn3" src="https://github.com/user-attachments/assets/4c2ceaef-dc0c-432b-8ad0-f367016a281b" />
<img width="585" height="342" alt="aaBmm3l" src="https://github.com/user-attachments/assets/d80aa2f4-c4cc-41c8-81fe-2f1875609d3e" />

This PR adds your rank discount to every single menu in the game. 

- Added shared FormatPriceBlock() function for consistent price display across all menus (classes, mechs, research, utility)
- Format: "Price: $700 [Officer -12% off]" when discounted, or just "Price: $300" when no discount. Free items show "Price: free!"
- Fixed class menu graying items when affordable after rank discount (CheckClassAvailability now uses discounted cost)
- Reordered all menus to show price first, then other info/description for consistency