### PR TITLE
[Cata] Add damage type info across all purchase menus

### DIFF
--- a/source/a_armor.acs
+++ b/source/a_armor.acs
@@ -6,14 +6,17 @@
 // due. Please don't be lame and just copy-paste any of this and call it your own. Thanks!
 
 // What type is weak against what?
-int ArmorWeaknesses[7] = {
-	ARMOD_NOCHANGE, // NOCHANGE
-	ARMOD_CHEM, // FIRE
-	ARMOD_FIRE, // CHEM
-	ARMOD_BULLETPROOF, // ENERGY
-	ARMOD_ENERGY, // EXPLO
-	ARMOD_EXPLO, // BULLETPROOF
-	ARMOD_CRYO, // ICE
+// [Cata] Armor weakness strings sourced from DECORATE damagefactors (actors/crucial/armor.txt).
+// Indexed by ARMOD_* constants. Empty string means no weaknesses.
+str ArmorWeaknessStr[8] = {
+	"",                              // 0: NOCHANGE
+	"\ca-Chem",                      // 1: FIRE
+	"\ca-Fire",                      // 2: CHEM
+	"\ca-Flak",                      // 3: ENERGY
+	"\ca-Energy",                    // 4: EXPLO
+	"\ca-Energy \ca-Flak \ca-Ice",   // 5: BULLET
+	"",                              // 6: NONE
+	"\ca-Bullet \ca-Energy \ca-Flak" // 7: CRYO
 };
 
 function int GetArmorGrade (void) {

--- a/source/a_armor.acs
+++ b/source/a_armor.acs
@@ -6,19 +6,6 @@
 // due. Please don't be lame and just copy-paste any of this and call it your own. Thanks!
 
 // What type is weak against what?
-// [Cata] Armor weakness strings sourced from DECORATE damagefactors (actors/crucial/armor.txt).
-// Indexed by ARMOD_* constants. Empty string means no weaknesses.
-str ArmorWeaknessStr[8] = {
-	"",                              // 0: NOCHANGE
-	"\ca-Chem",                      // 1: FIRE
-	"\ca-Fire",                      // 2: CHEM
-	"\ca-Flak",                      // 3: ENERGY
-	"\ca-Energy",                    // 4: EXPLO
-	"\ca-Energy \ca-Flak \ca-Ice",   // 5: BULLET
-	"",                              // 6: NONE
-	"\ca-Bullet \ca-Energy \ca-Flak" // 7: CRYO
-};
-
 function int GetArmorGrade (void) {
 	return GetPlayerArmorGrade (PlayerNumber ());
 }

--- a/source/a_credits.acs
+++ b/source/a_credits.acs
@@ -237,3 +237,4 @@ function int CalcDiscount (int amount) {
 	
 	return d;
 }
+

--- a/source/a_damagetypes.acs
+++ b/source/a_damagetypes.acs
@@ -1,0 +1,201 @@
+// [Cata] Centralized item info lookup system.
+// All damage type and effect data lives here. Sourced from DECORATE properties.
+// Uses named scripts to avoid function/variable limits.
+//
+// Categories:
+//   0 = Item (ITEM_* index)
+//   1 = Research (RESEARCH_* index)
+//   2 = Utility (PF_* index)
+//
+// Usage: str info = ACS_NamedExecuteWithResult("GetItemInfo", category, index);
+
+// Convert a single type ID to a colored string
+script "InfoIdToStr" (int id) CLIENTSIDE {
+	switch (id) {
+		// Damage types
+		case DMG_BULLET:   SetResultValue(strparam(s:"\cUBullet")); break;
+		case DMG_FIRE:     SetResultValue(strparam(s:"\cGFire")); break;
+		case DMG_CHEM:     SetResultValue(strparam(s:"\cDChem")); break;
+		case DMG_ENERGY:   SetResultValue(strparam(s:"\cNEnergy")); break;
+		case DMG_FLAK:     SetResultValue(strparam(s:"\cFFlak")); break;
+		case DMG_ICE:      SetResultValue(strparam(s:"\cVIce")); break;
+		case DMG_ANTIMECH: SetResultValue(strparam(s:"\cbAnti-mech")); break;
+		case DMG_MINE:     SetResultValue(strparam(s:"\csAnti-Personnel")); break;
+		case DMG_FLASH:    SetResultValue(strparam(s:"\cjFlash")); break;
+		case DMG_CONTACT:  SetResultValue(strparam(s:"\cpContact")); break;
+		case DMG_TIME:     SetResultValue(strparam(s:"\ciTime")); break;
+		case DMG_SUPER:    SetResultValue(strparam(s:"\ctSuper")); break;
+		case DMG_MELEE:    SetResultValue(strparam(s:"\cpMelee")); break;
+		// Passive/support effects
+		case EFF_DEFENSE10: SetResultValue(strparam(s:"\cq+10% Defence")); break;
+		case EFF_REPAIR:    SetResultValue(strparam(s:"\cnRepair")); break;
+		case EFF_HEAL:      SetResultValue(strparam(s:"\caHeal")); break;
+		case EFF_DISARM:    SetResultValue(strparam(s:"\csDisarm")); break;
+		case EFF_DECON:     SetResultValue(strparam(s:"\cjDeconstruct")); break;
+		case EFF_FIREPROOF: SetResultValue(strparam(s:"Armor: ", s:ArModColor(ARMOD_FIRE), s:ArModName(ARMOD_FIRE), s:" \cc(", s:ArmorWeaknessStr[ARMOD_FIRE], s:"\cc)")); break;
+		case EFF_CHEMPROOF: SetResultValue(strparam(s:"Armor: ", s:ArModColor(ARMOD_CHEM), s:ArModName(ARMOD_CHEM), s:" \cc(", s:ArmorWeaknessStr[ARMOD_CHEM], s:"\cc)")); break;
+		default:            SetResultValue(strparam(s:"")); break;
+	}
+}
+
+// Lookup item info string for any category.
+// Returns a fully formatted colored string like "\cUBullet \cc/ \cFFlak"
+// Packing: primary | (primary2 << 8) | (alt << 16) | (alt2 << 24)
+//   0 in any slot = not present
+//   comma separates primary+primary2, slash separates primary from alt
+script "GetItemInfo" (int category, int idx) CLIENTSIDE {
+	int packed = 0;
+
+	if (category == 0) { // Items (ITEM_* index)
+		switch (idx) {
+			case 1: case 2: case 3: case 4: case 5:
+				packed = DMG_BULLET; break;                                          // Handgun, SMG, Shotgun, SSG, MG
+			case 6:  packed = DMG_BULLET | (DMG_FLAK << 16); break;                 // Gatling (Bullet / Flak)
+			case 7:  packed = DMG_BULLET | (DMG_FLAK << 16); break;                 // Rifle (Bullet / Flak grenade)
+			case 8:  packed = DMG_ENERGY | (DMG_ANTIMECH << 16); break;             // Gauss (Energy / Anti-mech)
+			case 9:  packed = DMG_FLAK; break;                                      // Grenade Launcher
+			case 10: case 11: packed = DMG_ENERGY; break;                           // Stealth Laser, Laser Rifle
+			case 12: packed = DMG_TIME; break;                                      // Time Gun
+			case 13: packed = DMG_FLAK | (DMG_FIRE << 8) | (DMG_ANTIMECH << 16); break; // Artillery (Flak,Fire / Anti-mech)
+			case 14: packed = DMG_ENERGY; break;                                    // Laser Chaingun
+			case 16: packed = DMG_ENERGY; break;                                    // Plasma Cannon
+			case 17: packed = DMG_CHEM; break;                                      // Chemical Sprayer
+			case 18: packed = DMG_BULLET | (DMG_CHEM << 8); break;                  // Tiberium Auto (Bullet, Chem)
+			case 20: packed = EFF_REPAIR | (EFF_DISARM << 8); break;                // Upgraded Repair (Repair, Disarm)
+			case 21: packed = EFF_REPAIR | (EFF_DISARM << 8); break;                // Repair Gun (Repair, Disarm)
+			case 22: packed = EFF_DECON; break;                                     // Deconstruction Gun
+			case 23: packed = EFF_DISARM; break;                                    // Bomb Squad Gun
+			case 24: packed = EFF_HEAL; break;                                      // Heal Gun
+			case 25: packed = DMG_FLAK | (DMG_FIRE << 8); break;                    // Missile Launcher (Flak, Fire)
+			case 26: packed = DMG_FIRE; break;                                      // Flamethrower
+			case 27: packed = DMG_ENERGY; break;                                    // Shock Rifle
+			case 28: packed = DMG_BULLET; break;                                    // Sniper Rifle
+			case 29: packed = DMG_ENERGY; break;                                    // Plasma Rifle
+			case 30: packed = DMG_MELEE; break;                                     // Stealth Knife
+			case 31: packed = DMG_MELEE; break;                                     // Chainsaw
+			case 32: case 33: packed = DMG_FLAK; break;                             // Bomb Pack, Remote C4
+			case 35: case 36: packed = DMG_FLAK; break;                             // Mines
+			case 37: packed = EFF_HEAL; break;                                      // Medication Field
+			case 38: packed = EFF_DEFENSE10; break;                                 // +1 Armor (+10% Defense)
+			case 39: packed = DMG_SUPER; break;                                     // Beacon
+			case 40: case 41: packed = DMG_BULLET | (DMG_FIRE << 8); break;         // Combustion Auto (Bullet, Fire)
+			case 42: packed = DMG_BULLET; break;                                    // Sniper (weak)
+			case 43: packed = DMG_ICE; break;                                       // Cryo Bow
+			case 44: packed = DMG_ENERGY; break;                                    // Karasawa
+			case 45: packed = DMG_BULLET; break;                                    // Nail MG
+			case 46: packed = DMG_ENERGY; break;                                    // BFG 2704
+			case 47: packed = DMG_ENERGY; break;                                    // Stealth Gauss
+			case 48: packed = DMG_BULLET; break;                                    // Stealth Pistol
+		}
+	} else if (category == 1) { // Research (RESEARCH_* index)
+		switch (idx) {
+			case 4:  packed = DMG_FLAK; break;                                      // +1 Timed C4
+			case 8:  packed = DMG_MINE | (DMG_FIRE << 8); break;                    // +1 Frag Grenade (Anti-Personnel, Fire)
+			case 9:  packed = DMG_FLASH; break;                                     // +1 Flashbang
+		}
+	} else if (category == 2) { // Utility (PF_* index)
+		switch (idx) {
+			case 7:  packed = DMG_BULLET | (DMG_FLAK << 16); break;                 // Rifle pickup (Bullet / Flak)
+			case 8:  packed = DMG_BULLET; break;                                    // Machine Gun pickup
+			case 9:  packed = EFF_FIREPROOF; break;                                 // Fireproof armor
+			case 10: packed = EFF_CHEMPROOF; break;                                 // Chemproof armor
+			case 13: case 17: case 18: case 16:
+				packed = DMG_BULLET; break;                                          // Gun/Klaxon/Precision Turret, Mini-Raven
+			case 14: packed = DMG_ANTIMECH; break;                                  // Mech Turret
+			case 15: packed = DMG_MINE; break;                                      // Proxy Mine
+			case 19: packed = EFF_REPAIR; break;                                    // Repair Turret
+			case 20: packed = DMG_ANTIMECH | (DMG_FIRE << 8); break;                // Artillery Turret (Anti-mech, Fire)
+			case 21: packed = DMG_CONTACT; break;                                   // Razor Wire
+			case 32: packed = DMG_FIRE; break;                                      // Flame Turret
+			case 33: packed = DMG_CHEM; break;                                      // Chem Turret
+		}
+	}
+
+	if (packed == 0) { SetResultValue(strparam(s:"")); terminate; }
+
+	// Unpack: primary | (primary2 << 8) | (alt << 16) | (alt2 << 24)
+	int p1 = packed & 0xFF;
+	int p2 = (packed >> 8) & 0xFF;
+	int a1 = (packed >> 16) & 0xFF;
+	int a2 = (packed >> 24) & 0xFF;
+
+	str s1 = ACS_NamedExecuteWithResult("InfoIdToStr", p1);
+	str result = s1;
+
+	if (p2) result = strparam(s:result, s:"\cc, ", s:ACS_NamedExecuteWithResult("InfoIdToStr", p2));
+	if (a1) result = strparam(s:result, s:" \cc/ ", s:ACS_NamedExecuteWithResult("InfoIdToStr", a1));
+	if (a2) result = strparam(s:result, s:"\cc, ", s:ACS_NamedExecuteWithResult("InfoIdToStr", a2));
+
+	SetResultValue(result);
+}
+
+// [Cata] Helper: format a weapon line "WeaponName [DmgType1, DmgType2]"
+script "FmtMechWpn" (int packed, int nameStr) CLIENTSIDE {
+	int p1 = packed & 0xFF;
+	int p2 = (packed >> 8) & 0xFF;
+	str dmg = ACS_NamedExecuteWithResult("InfoIdToStr", p1);
+	if (p2) dmg = strparam(s:dmg, s:"\cc, ", s:ACS_NamedExecuteWithResult("InfoIdToStr", p2));
+	SetResultValue(strparam(s:"\cD", s:nameStr, s:" \cc[", s:dmg, s:"\cc]"));
+}
+
+// [Cata] Returns full weapon list for a mech, formatted as multi-line string.
+// Each weapon on its own line with damage types.
+script "GetMechWeapons" (int mechIdx) CLIENTSIDE {
+	str result = "";
+
+	switch (mechIdx) {
+	case 0: // Orca
+		result = strparam(
+			s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_BULLET, "Machine Gun"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK, "Rocket Pods"));
+		break;
+	case 1: // Tortoise
+		result = strparam(
+			s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_ENERGY, "Plasma Rifle"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK, "Impact Grenades"));
+		break;
+	case 2: // Raven
+		result = strparam(
+			s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_BULLET | (DMG_FLAK << 8), "AC-2"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK, "LRM-5"));
+		break;
+	case 3: // Mastodon
+		result = strparam(
+			s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK, "Homing Missiles"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK | (DMG_FIRE << 8), "Flame Grenades"));
+		break;
+	case 4: // Wolverine
+		result = strparam(
+			s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK, "LRM-10"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_ENERGY, "Pulse Cannon"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_BULLET, "Minigun"));
+		break;
+	case 5: // Mad Cat
+		result = strparam(
+			s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_ENERGY | (DMG_FLAK << 8), "2x Shock Cannon"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_ENERGY, "2x Shock Rifle"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK, "LRM-20"));
+		break;
+	case 6: // Titan
+		result = strparam(
+			s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_ANTIMECH | (DMG_FIRE << 8), "100mm Cannon"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FIRE, "2x Flamer"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK, "LRM-20"));
+		break;
+	case 7: // Lancer
+		result = strparam(
+			s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK, "LRM-10"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_ENERGY, "Plasma Cannon"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_CHEM, "Chem Sprayer"));
+		break;
+	case 8: // Juggernaut
+		result = strparam(
+			s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_ANTIMECH | (DMG_FIRE << 8), "2x Artillery 80mm"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_ANTIMECH | (DMG_FIRE << 8), "2x Anti-Mech SRM-15"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK, "2x Flak Cannon"),
+			s:"\n", s:ACS_NamedExecuteWithResult("FmtMechWpn", DMG_FLAK, "Mini-Nuke/Ion Bomb"));
+		break;
+	}
+
+	SetResultValue(result);
+}

--- a/source/a_damagetypes.acs
+++ b/source/a_damagetypes.acs
@@ -9,6 +9,36 @@
 //
 // Usage: str info = ACS_NamedExecuteWithResult("GetItemInfo", category, index);
 
+// [Cata] Armor weakness string lookup — replaces the ArmorWeaknessStr map variable array.
+// Returns colored weakness string for an ARMOD_* type, e.g. "\ca-Chem" for Fire armor.
+script "GetArmorWeakStr" (int armod) CLIENTSIDE {
+	switch (armod) {
+		case ARMOD_FIRE:        SetResultValue(strparam(s:"\ca-Chem")); break;
+		case ARMOD_CHEM:        SetResultValue(strparam(s:"\ca-Fire")); break;
+		case ARMOD_ENERGY:      SetResultValue(strparam(s:"\ca-Flak")); break;
+		case ARMOD_EXPLO:       SetResultValue(strparam(s:"\ca-Energy")); break;
+		case ARMOD_BULLETPROOF: SetResultValue(strparam(s:"\ca-Energy \ca-Flak \ca-Ice")); break;
+		case ARMOD_CRYO:        SetResultValue(strparam(s:"\ca-Bullet \ca-Energy \ca-Flak")); break;
+		default:                SetResultValue(strparam(s:"")); break;
+	}
+}
+
+// [Cata] Returns full armor info string for a class, e.g. "Armor: Grade 2 Flak (-Energy)"
+// Replaces ClassArmorInfo map variable array and BuildClassArmorInfo function.
+script "GetClassArmor" (int classId) CLIENTSIDE {
+	int armor = Classes_int[classId][CK_ARMOR];
+	int armod = Classes_int[classId][CK_ARMOD];
+	str info;
+	if (armod != ARMOD_NOCHANGE) {
+		str weak = ACS_NamedExecuteWithResult("GetArmorWeakStr", armod);
+		info = strparam(s:"Armor: \cDGrade ", s:ArmorColor(armor), d:armor, s:" ", s:ArModColor(armod), s:ArModName(armod));
+		if (StrLen(weak) > 0)
+			info = strparam(s:info, s:" \cc(", s:weak, s:"\cc)");
+	} else
+		info = strparam(s:"Armor: \cDGrade ", s:ArmorColor(armor), d:armor);
+	SetResultValue(info);
+}
+
 // Convert a single type ID to a colored string
 script "InfoIdToStr" (int id) CLIENTSIDE {
 	switch (id) {
@@ -32,8 +62,8 @@ script "InfoIdToStr" (int id) CLIENTSIDE {
 		case EFF_HEAL:      SetResultValue(strparam(s:"\caHeal")); break;
 		case EFF_DISARM:    SetResultValue(strparam(s:"\csDisarm")); break;
 		case EFF_DECON:     SetResultValue(strparam(s:"\cjDeconstruct")); break;
-		case EFF_FIREPROOF: SetResultValue(strparam(s:"Armor: ", s:ArModColor(ARMOD_FIRE), s:ArModName(ARMOD_FIRE), s:" \cc(", s:ArmorWeaknessStr[ARMOD_FIRE], s:"\cc)")); break;
-		case EFF_CHEMPROOF: SetResultValue(strparam(s:"Armor: ", s:ArModColor(ARMOD_CHEM), s:ArModName(ARMOD_CHEM), s:" \cc(", s:ArmorWeaknessStr[ARMOD_CHEM], s:"\cc)")); break;
+		case EFF_FIREPROOF: SetResultValue(strparam(s:"Armor: ", s:ArModColor(ARMOD_FIRE), s:ArModName(ARMOD_FIRE), s:" \cc(", s:ACS_NamedExecuteWithResult("GetArmorWeakStr", ARMOD_FIRE), s:"\cc)")); break;
+		case EFF_CHEMPROOF: SetResultValue(strparam(s:"Armor: ", s:ArModColor(ARMOD_CHEM), s:ArModName(ARMOD_CHEM), s:" \cc(", s:ACS_NamedExecuteWithResult("GetArmorWeakStr", ARMOD_CHEM), s:"\cc)")); break;
 		default:            SetResultValue(strparam(s:"")); break;
 	}
 }

--- a/source/a_defs.acs
+++ b/source/a_defs.acs
@@ -97,7 +97,33 @@ str Items_Str[MAX_ITEMS][MAX_ITEMKEYS_str] = {
 	{"Mortar Launcher", "MortarLauncher", "MortarAmmo", ""},*/
 };
 
-int Items_Int[MAX_ITEMS][MAX_ITEMKEYS_int] = 
+// [Cata] Item info type IDs for the lookup system
+// These are used as packed values in the named script "GetItemInfo"
+// IDs 1-13: damage types, 14+: passive/support effects
+#define DMG_NONE        0
+#define DMG_BULLET      1
+#define DMG_FIRE        2
+#define DMG_CHEM        3
+#define DMG_ENERGY      4
+#define DMG_FLAK        5
+#define DMG_ICE         6
+#define DMG_ANTIMECH    7
+#define DMG_MINE        8
+#define DMG_FLASH       9
+#define DMG_CONTACT     10
+#define DMG_TIME        11
+#define DMG_SUPER       12
+#define DMG_MELEE       13
+// Passive/support effects
+#define EFF_DEFENSE10   14
+#define EFF_REPAIR      15
+#define EFF_HEAL        16
+#define EFF_DISARM      17
+#define EFF_DECON       18
+#define EFF_FIREPROOF   19
+#define EFF_CHEMPROOF   20
+
+int Items_Int[MAX_ITEMS][MAX_ITEMKEYS_int] =
 {
 	// num weps to give, ammo for main fire, ammo for alt fire, resell value
 	{0, 0, 0, 0}, // Mandatory empty entry for no item
@@ -522,14 +548,7 @@ str Mechs_str[NUM_MECHS][NUM_MECH_KEYS_STR] = {
 		//"0",
 		"		A light VTOL armed with a machine gun and\n
 		rockets. Designed against infantry but\n
-		loses hard against heavier firepower.\n
-		\n
-		\n
-		\n
-		\n
-		Weapons:\n
-		\t- Machine Gun\n
-		\t- Rocket pods"
+		loses hard against heavier firepower."
 	},
 	{
 		"Tortoise", 
@@ -544,11 +563,7 @@ str Mechs_str[NUM_MECHS][NUM_MECH_KEYS_STR] = {
 		and tear infantry apart. Its very slow\n
 		speed and inability to hit buildings from\n
 		the outside solidifies its role as area\n
-		denial and ambushing in enemy territory.\n
-		\n
-		Weapons:\n
-		\t- Explosive Plasma Rifle\n
-		\t- Impact Grenades"
+		denial and ambushing in enemy territory."
 	},
 	{
 		"Raven", 
@@ -563,11 +578,7 @@ str Mechs_str[NUM_MECHS][NUM_MECH_KEYS_STR] = {
 		Reports also indicate harvesters using\n
 		Ravens for a safer harvesting trip.\n
 		These mechs can also be built by\n
-		Utility Guys.\n
-		\n
-		Weapons:\n
-		\t- AC-2\n
-		\t- LRM-5"
+		Utility Guys."
 	},
 	{
 		"Mastodon",
@@ -577,11 +588,7 @@ str Mechs_str[NUM_MECHS][NUM_MECH_KEYS_STR] = {
 		designed for chasing off infantry rushes.\n
 		Armed with dual homing missiles and dual\n
 		exploding flame grenades allows the tank\n
-		to attack from all ranges.\n
-		\n
-		Weapons:\n
-		\t- Dual Homing Missiles\n
-		\t- Dual Flame Grenades"
+		to attack from all ranges."
 	},
 	{
 		"Wolverine", 
@@ -594,14 +601,7 @@ str Mechs_str[NUM_MECHS][NUM_MECH_KEYS_STR] = {
 		"		A medium, heavier mechs packed with\n
 		heavier anti-infantry firepower at\n
 		the cost of speed. These mechs can\n
-		also be built by Utility Guys.\n
-		\n
-		\n
-		\n
-		Weapons:\n
-		\t- LRM-10\n
-		\t- Pulse Cannon\n
-		\t- Minigun"
+		also be built by Utility Guys."
 	}, 
 	{
 		"Mad Cat", 
@@ -613,12 +613,7 @@ str Mechs_str[NUM_MECHS][NUM_MECH_KEYS_STR] = {
 		//MF_POWER,
 		"		A heavy all-around mech designed to hold\n
 		its own against both infantry and mechs\n
-		and can also hit on buildings.\n
-		\n
-		Weapons:\n
-		\t- 2x Shock Cannon\n
-		\t- 2x Shock Rifle\n
-		\t- LRM-20"
+		and can also hit on buildings."
 	}, 
 	
 	{
@@ -634,12 +629,7 @@ str Mechs_str[NUM_MECHS][NUM_MECH_KEYS_STR] = {
 		performs less good at infantry than\n
 		the Mad Cat. However, the 100mm cannon\n
 		has proven its use time and time\n
-		again...\n
-		\n
-		Weapons:\n
-		\t- 100mm Cannon\n
-		\t- 2x Flamer\n
-		\t- LRM-20"
+		again..."
 	}, 
 	
 	{
@@ -649,12 +639,7 @@ str Mechs_str[NUM_MECHS][NUM_MECH_KEYS_STR] = {
 		"		A medium mech designed for fighting\n
 		and defending against other mechs. Comes armed\n
 		with missiles, a chemical sprayer, and a plasma\n
-		cannon.\n
-		\n
-		Weapons:\n
-		\t- LRM-10\n
-		\t- Plasma Cannon\n
-		\t- Chemical Sprayer"
+		cannon."
 	}, 
 	
 	{
@@ -670,14 +655,7 @@ str Mechs_str[NUM_MECHS][NUM_MECH_KEYS_STR] = {
 		to metal bits before they can even spell\n
 		its name. It is also effective on buildings.\n
 		However, its slow speed and anti-armor\n
-		weapons make it a sitting duck for infantry.\n
-		\n
-		\n
-		Weapons:\n
-		\t- 2x Artillery Cannon 80mm\n
-		\t- 2x Anti-Mech SRM-15\n
-		\t- 2x Flak Cannon\n
-		\t- Mini-Nuke Artillery"
+		weapons make it a sitting duck for infantry."
 	}, 
 };
 

--- a/source/a_menu.acs
+++ b/source/a_menu.acs
@@ -283,8 +283,8 @@ function void ClearMenu (void) {
 	for (i = 0; i <= MAX_MENU_ITEMS; i++)
 		ClearHudMessage (MENU_HID + 10 + i);
 	
-	// Clear item description and arrow markers
-	for (i = 0; i <= 3; i++) {
+	// [Cata] Clear item description and arrow markers (expanded to +24 for type/weapons/build time lines)
+	for (i = 0; i <= 4; i++) {
 		ClearHudMessage (MENU_HID + 20 + i);
 		ClearHudMessage (MENU_HID + 60 + i);
 	}

--- a/source/a_menu_factory.acs
+++ b/source/a_menu_factory.acs
@@ -27,18 +27,13 @@ script 706 (void) CLIENTSIDE {
 // MENU DRAW
 script 707 (int m0, int m1, int y) CLIENTSIDE {
 	int hid = MENU_HID + 21;
-	
-	// Health
-	HudMessage (s:"Health: \cd", d:Mechs_int[MenuMechs[m0][m1]][MK_HEALTH], s:" \cqHP";
-		HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
-		y -= MENU_SPACING; hid++;
-	
-	// Price - Check for discount to apply on menu itself its easyer to read that way.
-	int Cost  = Mechs_int[MenuMechs[m0][m1]][MK_COST];
-	int Discount  = CalcDiscount(Cost);
+	int mechIdx = MenuMechs[m0][m1];
+
+	// Price
+	int Cost = Mechs_int[mechIdx][MK_COST];
+	int Discount = CalcDiscount(Cost);
 	int Final = Cost - Discount;
-	// HudMessage (s:"Cost: \cq$\cd", d:Mechs_int[MenuMechs[m0][m1]][MK_COST];
-	if (Cost != Final) // Has discount, show it.
+	if (Cost != Final)
 	{
 		HudMessage (s:"Cost: \cq$\cn", d:Final, s:"  \cc(\cq$\cc", d:Discount, s:" - \cq$\cd", d:Cost, s:"\cc)";
 		HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
@@ -46,15 +41,33 @@ script 707 (int m0, int m1, int y) CLIENTSIDE {
 	}
 	else
 	{
-	HudMessage (s:"Cost: \cq$\cd", d:Final;
+		HudMessage (s:"Cost: \cq$\cd", d:Final;
 		HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
 		y -= MENU_SPACING; hid++;
 	}
-	
-	// Description - shifted a bit to the left to compensate for tabs
-	HudMessage (s:Mechs_str[MenuMechs[m0][m1]][MK_DESCRIPTION];
+
+	// Health
+	HudMessage (s:"Health: \cd", d:Mechs_int[mechIdx][MK_HEALTH], s:" \cqHP";
+		HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
+	y -= MENU_SPACING; hid++;
+
+	// [Cata] Weapons with damage types
+	str weapons = ACS_NamedExecuteWithResult("GetMechWeapons", mechIdx);
+	if (StrLen(weapons) > 0) {
+		HudMessage (s:"Weapons:\n", s:weapons;
+			HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
+		// Count newlines to adjust y
+		int wlines = 1;
+		for (int ci = 0; ci < StrLen(weapons); ci++)
+			if (GetChar(weapons, ci) == '\n') wlines++;
+		y -= MENU_SPACING * wlines;
+		hid++;
+	}
+
+	// Description
+	HudMessage (s:Mechs_str[mechIdx][MK_DESCRIPTION];
 		HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4-0.025, y, 0.0);
-		y -= 0.1; hid++;
+	y -= 0.1; hid++;
 	
 	SetResultValue (y);
 }

--- a/source/a_menu_purchase.acs
+++ b/source/a_menu_purchase.acs
@@ -1,10 +1,42 @@
+// [Cata] Precomputed armor info strings per class
+str ClassArmorInfo[NUMCLASSES];
+bool ClassArmorInfoBuilt;
+
+// [Cata] Format weapon name with damage type
+function str FormatWeaponLine (int itemId) {
+	str name = Items_Str[itemId][IK_NAME];
+	if (StrLen(name) == 0) return "";
+	str dmg = ACS_NamedExecuteWithResult("GetItemInfo", 0, itemId);
+	if (StrLen(dmg) > 0)
+		return strparam(s:"\cD", s:name, s:" \cc[", s:dmg, s:"\cc]");
+	return strparam(s:"\cD", s:name);
+}
+
+function void BuildClassArmorInfo (void) {
+	if (ClassArmorInfoBuilt) return;
+	for (int id = 0; id < NUMCLASSES; id++) {
+		int armor = Classes_int[id][CK_ARMOR];
+		int armod = Classes_int[id][CK_ARMOD];
+		str info;
+		if (armod != ARMOD_NOCHANGE) {
+			info = strparam(s:"Armor: \cDGrade ", s:ArmorColor(armor), d:armor, s:" ", s:ArModColor(armod), s:ArModName(armod));
+			if (StrLen(ArmorWeaknessStr[armod]) > 0)
+				info = strparam(s:info, s:" \cc(", s:ArmorWeaknessStr[armod], s:"\cc)");
+		} else
+			info = strparam(s:"Armor: \cDGrade ", s:ArmorColor(armor), d:armor);
+		ClassArmorInfo[id] = info;
+	}
+	ClassArmorInfoBuilt = true;
+}
+
 // =============================================================================
 // MENU INIT
 script 702 (void) CLIENTSIDE {
 	// If the menu-class table hasn't been built yet, do so now
 	if (!(MenuTables & MTABLE_CLASSES))
 		BuildMenuClasses ();
-	
+	BuildClassArmorInfo ();
+
 	MenuName = "PURCHASE TERMINAL";
 	MenuCategories[0] = "GENERIC";
 	MenuCategories[1] = "COMBAT";
@@ -45,70 +77,46 @@ script 703 (int m0, int m1, int y) CLIENTSIDE {
 	case 2: case 3:
 		// Display discount, if any
 		ACS_ExecuteWithResult (330, Classes_int[id][CK_COST]);
-		
-		int armor = Classes_int[id][CK_ARMOR];
-		int armod = Classes_int[id][CK_ARMOD];
-		
-		str item0 = Items_Str[Classes_int[id][CK_ITEM0]][IK_NAME];
-		str item1 = Items_str[Classes_int[id][CK_ITEM1]][IK_NAME];
-		str item2 = Items_str[Classes_int[id][CK_ITEM2]][IK_NAME];
-		str item3 = Items_str[Classes_int[id][CK_ITEM3]][IK_NAME];
-		str item4 = Items_str[Classes_int[id][CK_ITEM4]][IK_NAME];
-		str item5 = Items_str[Classes_int[id][CK_ITEM5]][IK_NAME];
-		
-		// Determine strengths and weaknesses
-		int dtype;
-		int weaktype;
-		str weakness;
-		
-		if (armod == ARMOD_NOCHANGE) {
-			// If we don't have any armor type, we're not really
-			// weak per se towards anything. And if we don't have an
-			// armor type we usually deal bullet damage (unless we're
-			// support, in which case these aren't displayed anyway)
-			// Therefore, our weakness is bullets.
-			dtype = ARMOD_BULLETPROOF;
-			weaktype = ARMOD_BULLETPROOF;
-		} else {
-			dtype = armod;
-			weaktype = ArmorWeaknesses[dtype];
-		}
-		
-		weakness = strparam (s:ArModColor (weaktype), s:ArModName (weaktype));
-		
-		// We're strong against whatever is weak against us.
-		str strength = "";
-		for (int i = 1; i < ARMOD_NONE; i++)
-			if (ArmorWeaknesses[i] == dtype)
-				strength = strparam (s:strength, s:" ", s:ArModColor (i), s:ArModName (i));
-		
-		// TODO: Break this down to individual hudmessages for flexibility
+
+		// [Cata] Format weapon names with damage types
+		str item0 = FormatWeaponLine(Classes_int[id][CK_ITEM0]);
+		str item1 = FormatWeaponLine(Classes_int[id][CK_ITEM1]);
+		str item2 = FormatWeaponLine(Classes_int[id][CK_ITEM2]);
+		str item3 = FormatWeaponLine(Classes_int[id][CK_ITEM3]);
+		str item4 = FormatWeaponLine(Classes_int[id][CK_ITEM4]);
+		str item5 = FormatWeaponLine(Classes_int[id][CK_ITEM5]);
+
 		str classinfo;
 		classinfo = strparam (s:"Speed: \cD", d:(Classes_int[id][CK_SPEED] * 100) >> 16,
 			s:"\cQ%\nPrice: \cQ$\cD", d:Classes_int[id][CK_COST],
-			s:"\nArmor: \cDGrade ", s:ArmorColor (armor), d:armor, s:" ", s:ArModColor (armod), s:ArModName (armod));
-			
-		// Unless we're a support class, write down strengths and weaknesses
-		if (Classes_int[id][CK_FLAGS] & CF_IsTimeCop) {
-			classinfo = strparam (s:classinfo,
-				s:"\nStrength: ", s:strength,
-				s:"\nWeakness: ", s:weakness);
-		}
-		
+			s:"\n", s:ClassArmorInfo[id]);
+
 		// Write down the rest of the info
 		classinfo = strparam (s:classinfo,
 			s:"\nGrenades: \cD", d:Classes_int[id][CK_FRAGS],
 			s:"\nC4: \cD", d:Classes_int[id][CK_C4],
-			s:"\n----\n\cD",
-			s:item0, s:"\n\cD", s:item1, s:"\n\cD", s:item2, s:"\n\cD",
-			s:item3, s:"\n\cD", s:item4, s:"\n\cD", s:item5, s:"\n\cD");
+			s:"\n----");
+		if (StrLen(item0) > 0) classinfo = strparam(s:classinfo, s:"\n", s:item0);
+		if (StrLen(item1) > 0) classinfo = strparam(s:classinfo, s:"\n", s:item1);
+		if (StrLen(item2) > 0) classinfo = strparam(s:classinfo, s:"\n", s:item2);
+		if (StrLen(item3) > 0) classinfo = strparam(s:classinfo, s:"\n", s:item3);
+		if (StrLen(item4) > 0) classinfo = strparam(s:classinfo, s:"\n", s:item4);
+		if (StrLen(item5) > 0) classinfo = strparam(s:classinfo, s:"\n", s:item5);
 		
 		// Draw it now.
 		HudMessage (s:classinfo; HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X4, y, 0.0);
 		break;
 	case 4:
+		// [Cata] Show add-on price and damage type
 		ACS_ExecuteWithResult (330, Addons_int[m1][ADK_COST] - CalcDiscount(Addons_int[m1][ADK_COST]));
-		HudMessage (s:"Price: \cQ$\cD", d:Addons_int[m1][ADK_COST];
+		int addonItem = Addons_int[m1][ADK_ITEM];
+		str addonDmg = ACS_NamedExecuteWithResult("GetItemInfo", 0, addonItem);
+		str addonInfo2 = strparam(s:"Price: \cQ$\cD", d:Addons_int[m1][ADK_COST]);
+		if (addonItem == ITEM_ArmorUp)
+			addonInfo2 = strparam(s:addonInfo2, s:"\n", s:addonDmg);
+		else if (StrLen(addonDmg) > 0)
+			addonInfo2 = strparam(s:addonInfo2, s:"\nType: \cc[", s:addonDmg, s:"\cc]");
+		HudMessage (s:addonInfo2;
 			HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X4, y, 0.0);
 		break;
 	case 5:

--- a/source/a_menu_purchase.acs
+++ b/source/a_menu_purchase.acs
@@ -1,7 +1,3 @@
-// [Cata] Precomputed armor info strings per class
-str ClassArmorInfo[NUMCLASSES];
-bool ClassArmorInfoBuilt;
-
 // [Cata] Format weapon name with damage type
 function str FormatWeaponLine (int itemId) {
 	str name = Items_Str[itemId][IK_NAME];
@@ -12,22 +8,6 @@ function str FormatWeaponLine (int itemId) {
 	return strparam(s:"\cD", s:name);
 }
 
-function void BuildClassArmorInfo (void) {
-	if (ClassArmorInfoBuilt) return;
-	for (int id = 0; id < NUMCLASSES; id++) {
-		int armor = Classes_int[id][CK_ARMOR];
-		int armod = Classes_int[id][CK_ARMOD];
-		str info;
-		if (armod != ARMOD_NOCHANGE) {
-			info = strparam(s:"Armor: \cDGrade ", s:ArmorColor(armor), d:armor, s:" ", s:ArModColor(armod), s:ArModName(armod));
-			if (StrLen(ArmorWeaknessStr[armod]) > 0)
-				info = strparam(s:info, s:" \cc(", s:ArmorWeaknessStr[armod], s:"\cc)");
-		} else
-			info = strparam(s:"Armor: \cDGrade ", s:ArmorColor(armor), d:armor);
-		ClassArmorInfo[id] = info;
-	}
-	ClassArmorInfoBuilt = true;
-}
 
 // =============================================================================
 // MENU INIT
@@ -35,8 +15,6 @@ script 702 (void) CLIENTSIDE {
 	// If the menu-class table hasn't been built yet, do so now
 	if (!(MenuTables & MTABLE_CLASSES))
 		BuildMenuClasses ();
-	BuildClassArmorInfo ();
-
 	MenuName = "PURCHASE TERMINAL";
 	MenuCategories[0] = "GENERIC";
 	MenuCategories[1] = "COMBAT";
@@ -89,7 +67,7 @@ script 703 (int m0, int m1, int y) CLIENTSIDE {
 		str classinfo;
 		classinfo = strparam (s:"Speed: \cD", d:(Classes_int[id][CK_SPEED] * 100) >> 16,
 			s:"\cQ%\nPrice: \cQ$\cD", d:Classes_int[id][CK_COST],
-			s:"\n", s:ClassArmorInfo[id]);
+			s:"\n", s:ACS_NamedExecuteWithResult("GetClassArmor", id));
 
 		// Write down the rest of the info
 		classinfo = strparam (s:classinfo,

--- a/source/a_menu_research.acs
+++ b/source/a_menu_research.acs
@@ -25,15 +25,27 @@ script 704 (void) CLIENTSIDE {
 // =============================================================================
 // MENU DRAW
 script 705 (int m0, int m1, int y) CLIENTSIDE {
-	HudMessage (s:Researches_str[MenuResearches[m0][m1]][RCK_DESCRIPTION];
-		HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X4, y, 0.0);
-	y -= 0.1;
-		
+	int resIdx = MenuResearches[m0][m1];
+
 	// Price
-	HudMessage (s:"Cost: \cq$\cd", d:Researches_int[MenuResearches[m0][m1]][RCK_COST];
-		HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
+	HudMessage (s:"Cost: \cq$\cd", d:Researches_int[resIdx][RCK_COST];
+		HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X4, y, 0.0);
 	y -= MENU_SPACING;
-	
+
+	// [Cata] Damage type if applicable
+	str resDmg = ACS_NamedExecuteWithResult("GetItemInfo", 1, resIdx);
+	if (StrLen(resDmg) > 0) {
+		HudMessage (s:"Type: \cc[", s:resDmg, s:"\cc]";
+			HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
+		y -= MENU_SPACING;
+	} else
+		HudMessage (s:""; HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
+
+	// Description
+	HudMessage (s:Researches_str[resIdx][RCK_DESCRIPTION];
+		HUDMSG_PLAIN, MENU_HID + 23, CR_WHITE, UMENU_X4, y, 0.0);
+	y -= 0.1;
+
 	SetResultValue (y);
 }
 

--- a/source/a_menu_util.acs
+++ b/source/a_menu_util.acs
@@ -25,27 +25,56 @@ script 700 (void) CLIENTSIDE {
 // MENU DRAW
 script 701 (int m0, int m1, int y) CLIENTSIDE {
 	int x = PF_FindDefByMenuCoords (m0, m1);
-	
-	// Description
-	HudMessage (s:g_ParticleFuserData_str[x][UK_DESCRIPTION];
-		HUDMSG_PLAIN, MENU_HID + 21, CR_WHITE, UMENU_X4, y, 0.0);
-	y -= 0.1;
-	
+	int hid = MENU_HID + 21;
+
 	// Price
 	if (g_ParticleFuserData_int[x][UK_COST] > 0)
 		HudMessage (s:"Cost: \cq$\cd", d:g_ParticleFuserData_int[x][UK_COST];
-			HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
+			HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
 	else
 		HudMessage (s:"Cost: \cdfree!";
-			HUDMSG_PLAIN, MENU_HID + 22, CR_WHITE, UMENU_X4, y, 0.0);
-	y -= MENU_SPACING;
-	
+			HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
+	y -= MENU_SPACING; hid++;
+
+	// [Cata] Damage type / weapons / effect info
+	if (x == PF_RAVEN || x == PF_WOLVERINE) {
+		// Mechs get multi-line weapon lists
+		int mechId = (x == PF_RAVEN) ? MECH_RAVEN : MECH_WOLVERINE;
+		str weapons = ACS_NamedExecuteWithResult("GetMechWeapons", mechId);
+		HudMessage (s:"Weapons:\n", s:weapons;
+			HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
+		int wlines = 1;
+		for (int ci = 0; ci < StrLen(weapons); ci++)
+			if (GetChar(weapons, ci) == '\n') wlines++;
+		y -= MENU_SPACING * wlines;
+	} else {
+		str utilDmg = ACS_NamedExecuteWithResult("GetItemInfo", 2, x);
+		if (StrLen(utilDmg) > 0) {
+			if (x == PF_FIREPROOF || x == PF_CHEMPROOF)
+				HudMessage (s:utilDmg;
+					HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
+			else
+				HudMessage (s:"Type: \cc[", s:utilDmg, s:"\cc]";
+					HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
+			y -= MENU_SPACING;
+		} else
+			HudMessage (s:""; HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
+	}
+	hid++;
+
+	// Description
+	HudMessage (s:g_ParticleFuserData_str[x][UK_DESCRIPTION];
+		HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
+	y -= 0.1; hid++;
+
 	// Build time
 	if (g_ParticleFuserData_int[x][UK_BUILDTIME] > 0) {
 		HudMessage (s:"Build time: \cd", f:g_ParticleFuserData_int[x][UK_BUILDTIME], s:" \cqseconds";
-			HUDMSG_PLAIN, MENU_HID + 23, CR_WHITE, UMENU_X4, y, 0.0);
+			HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
 		y -= MENU_SPACING;
-	}
+	} else
+		HudMessage (s:""; HUDMSG_PLAIN, hid, CR_WHITE, UMENU_X4, y, 0.0);
+	hid++;
 	
 	// Display the limit, if there is any
 	int lcur, lmax;

--- a/source/aow2scrp.acs
+++ b/source/aow2scrp.acs
@@ -818,6 +818,7 @@ global int 63:deathtoll;
 #include "a_functions.acs"
 #include "a_sync.acs"
 #include "a_credits.acs"
+#include "a_damagetypes.acs"
 #include "a_xp.acs"
 //#include "a_hax.acs"
 


### PR DESCRIPTION
<img width="497" height="259" alt="image" src="https://github.com/user-attachments/assets/7333c5e6-9ca5-49f8-b73c-b26003fb5fc1" />
<img width="630" height="223" alt="image" src="https://github.com/user-attachments/assets/cdf4104a-cc90-4252-b0b4-31cb3d3bd665" />
<img width="580" height="251" alt="image" src="https://github.com/user-attachments/assets/87153b9d-a53b-4212-b92e-6d8dfaa94302" />
<img width="470" height="113" alt="image" src="https://github.com/user-attachments/assets/51896120-45bc-4312-a222-810a9baf5937" />

Organized everything to the best of my ability on the right category. I was surprised to see that nailgun for example is actually a bullet type, and the ion is just flak. This should help make it super clear to everyone what does what.

- Weapons now display their damage type in brackets (e.g. Rifle [Bullet / Flak])
- Armor weakness shown inline on the armor line (e.g. Grade 2 Flak (-Energy))
- Mech weapons pulled out of descriptions into labeled section with damage types
- Add-on, research, and utility menus show item types where applicable
- Centralized damage type lookup via named scripts (a_damagetypes.acs)
- Fixed ArmorWeaknesses array out-of-bounds bug for Ice armor
- Fixed empty weapon slots producing blank lines in class menu
- Fixed stale HUD messages when switching menu items or closing menus