### PR TITLE
[Cata] Fix razor wire kills not crediting the player who built it

### DIFF
--- a/actors/objects/razorwire.txt
+++ b/actors/objects/razorwire.txt
@@ -5,6 +5,9 @@ actor RazorWire {
 	+NOBLOOD
 	+NODAMAGETHRUST
 	+NOICEDEATH
+	+ISMONSTER     // [Cata] Required for FriendPlayer kill attribution
+	+FRIENDLY      // [Cata] Prevents AI targeting
+	-COUNTKILL     // [Cata] Don't count toward monster kills
 	Health 400
 	Radius 32
 	Height 32


### PR DESCRIPTION
<img width="805" height="856" alt="image" src="https://github.com/user-attachments/assets/77fd9129-ab30-400b-a7ed-da91b6e45360" />
<img width="247" height="240" alt="image" src="https://github.com/user-attachments/assets/47636aba-317f-4251-9bb3-af5e0ba9025d" />

Currently if a player dies to razorwire it doesn't credit the person who initially spawned it. That's due to a combination of razorwires using ACS for its damage and the Zandronum engine losing track of actor ownership with how Utility guys spawn stuff. These DECORATE flags help Zandronum's engine piece everything together.

If the person who spawned it disconnects, it'll fall back to the old behavior so teamkilling won't occur. 