### PR TITLE
Fix double shotgun fire sound being cut off by reload sounds

### DIFF
--- a/actors/weapons/doubleshotgun.txt
+++ b/actors/weapons/doubleshotgun.txt
@@ -68,7 +68,7 @@ actor DoubleShotgun : AOWWeapon replaces SuperShotgun {
     FireBoth:
 		SHT2 A 3
 		SHT2 A 0 Radius_Quake(5,4,0,1,0)
-		TNT1 A 0 A_PlaySound ("weapons/sshotf", CHAN_WEAPON)
+		TNT1 A 0 A_PlaySound ("weapons/sshotf", CHAN_5)
 		TNT1 A 0 A_TakeInventory("SSGShell",2)
         TNT1 A 0 A_FireBullets (15.7, 11.7, 20, 5, "HandgunPuff", 1, 760)
         SG2F AB 2 BRIGHT
@@ -88,7 +88,7 @@ actor DoubleShotgun : AOWWeapon replaces SuperShotgun {
 	    Goto Empty
 		SG2F E 1 A_Light1
 		TNT1 A 0 Radius_Quake(3,4,0,1,0)
-		TNT1 A 0 A_PlaySound ("weapons/sshotf", CHAN_WEAPON)
+		TNT1 A 0 A_PlaySound ("weapons/sshotf", CHAN_5)
 		TNT1 A 0 A_TakeInventory("SSGShell",1)
 		TNT1 A 0 Bright A_FireBullets (7.4, 5.4, 8, 5, "HandgunPuff", 1, 1024)
 		SG2F F 2 bright A_Light2
@@ -99,7 +99,7 @@ actor DoubleShotgun : AOWWeapon replaces SuperShotgun {
     AltFireLeft:
 		SG2F C 1 A_Light1
 		TNT1 A 0 Radius_Quake(3,4,0,1,0)
-		TNT1 A 0 A_PlaySound ("weapons/sshotf", CHAN_WEAPON)
+		TNT1 A 0 A_PlaySound ("weapons/sshotf", CHAN_5)
 		TNT1 A 0 A_TakeInventory("SSGShell",1)
 		TNT1 A 0 Bright A_FireBullets (7.4, 5.4, 8, 5, "HandgunPuff", 1, 1024)
 		SG2F D 2 bright A_Light2


### PR DESCRIPTION
This will stop the SSG's fire sound from being abruptly interrupted by the reload.